### PR TITLE
feat: add collapsible sidebar

### DIFF
--- a/app/_components/FeatureComponents/FilesPage/MobileSidebarWrapper.tsx
+++ b/app/_components/FeatureComponents/FilesPage/MobileSidebarWrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, cloneElement, isValidElement, ReactElement } from "react";
 import IconButton from "@/app/_components/GlobalComponents/Buttons/IconButton";
 import { useSidebar } from "@/app/_providers/SidebarProvider";
 
@@ -13,7 +13,13 @@ export default function MobileSidebarWrapper({
   sidebar,
   children,
 }: MobileSidebarWrapperProps) {
-  const { isSidebarOpen, openSidebar, closeSidebar } = useSidebar();
+  const {
+    isSidebarOpen,
+    openSidebar,
+    closeSidebar,
+    isCollapsed,
+    toggleCollapse,
+  } = useSidebar();
   const sidebarRef = useRef<HTMLDivElement>(null);
   const touchStartX = useRef<number | null>(null);
   const touchStartY = useRef<number | null>(null);
@@ -84,7 +90,14 @@ export default function MobileSidebarWrapper({
     return () => {
       document.removeEventListener("touchmove", handleSwipeClose);
     };
-  }, [isSidebarOpen, openSidebar]);
+  }, [isSidebarOpen, closeSidebar]);
+
+  // Clone sidebar element and pass isCollapsed prop
+  const sidebarWithProps = isValidElement(sidebar)
+    ? cloneElement(sidebar as ReactElement<{ isCollapsed?: boolean }>, {
+        isCollapsed,
+      })
+    : sidebar;
 
   return (
     <>
@@ -95,8 +108,37 @@ export default function MobileSidebarWrapper({
         />
       )}
 
-      <aside className="w-96 bg-sidebar flex-shrink-0 hidden medium:block overflow-hidden">
-        {sidebar}
+      <aside
+        className={`bg-sidebar flex-shrink-0 hidden medium:flex flex-col overflow-hidden transition-all duration-300 ease-in-out ${
+          isCollapsed ? "w-16" : "w-64"
+        }`}
+      >
+        {/* Collapse toggle button */}
+        <div
+          className={`flex items-center p-2 border-b border-outline-variant/20 ${
+            isCollapsed ? "justify-center" : "justify-end"
+          }`}
+          onDragOver={(e) => e.stopPropagation()}
+          onDrop={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggleCollapse();
+            }}
+            className="p-2 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-variant/30 transition-colors"
+            title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            <span className="material-symbols-outlined text-xl">
+              {isCollapsed ? "chevron_right" : "chevron_left"}
+            </span>
+          </button>
+        </div>
+        <div className="flex-1 overflow-hidden">
+          {sidebarWithProps}
+        </div>
       </aside>
 
       <aside

--- a/app/_components/FeatureComponents/SettingsPage/SettingsPage.tsx
+++ b/app/_components/FeatureComponents/SettingsPage/SettingsPage.tsx
@@ -15,18 +15,22 @@ import FilesPageBorderWrapper from "@/app/_components/GlobalComponents/Files/Fil
 import FilesPageWrapper from "@/app/_components/GlobalComponents/Files/FilesPageWrapper";
 import Icon from "@/app/_components/GlobalComponents/Icons/Icon";
 import Select from "@/app/_components/GlobalComponents/Form/Select";
-import { SidebarProvider } from "@/app/_providers/SidebarProvider";
+import { SidebarProvider, useSidebar } from "@/app/_providers/SidebarProvider";
 import { usePreferences } from "@/app/_providers/PreferencesProvider";
 
 type Tab = "profile" | "preferences" | "encryption" | "users" | "audit-logs";
 
-export default function SettingsPage() {
+function SettingsContent() {
   const { user } = usePreferences();
+  const {
+    isCollapsed,
+    toggleCollapse,
+  } = useSidebar();
+  const [activeTab, setActiveTab] = useState<Tab>("profile");
 
   if (!user) {
     return null;
   }
-  const [activeTab, setActiveTab] = useState<Tab>("profile");
 
   const tabs: { id: Tab; label: string; icon: string }[] = [
     { id: "profile", label: "Profile", icon: "person" },
@@ -41,71 +45,101 @@ export default function SettingsPage() {
   ];
 
   return (
+    <FilesPageWrapper folderPath="">
+      <div className="flex-shrink-0">
+        <TopAppBar
+          leading={
+            <Link
+              href="/"
+              className="flex items-center justify-center leading-[0] gap-2 pt-8 pb-2 -ml-4"
+            >
+              <Logo className="w-16 h-16 lg:w-20 lg:h-20" hideBox={true} />
+            </Link>
+          }
+          trailing={
+            <div className="flex items-center gap-2">
+              <ThemeSelector />
+              <UserMenu />
+            </div>
+          }
+        />
+      </div>
+      <div className="flex flex-1 overflow-hidden min-h-0">
+        <aside
+          className={`hidden lg:flex flex-col bg-sidebar overflow-y-auto flex-shrink-0 transition-all duration-300 ease-in-out ${
+            isCollapsed ? "w-16" : "w-64"
+          }`}
+        >
+          {/* Collapse toggle button */}
+          <div className={`flex items-center p-2 border-b border-outline-variant/20 ${
+            isCollapsed ? "justify-center" : "justify-end"
+          }`}>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleCollapse();
+              }}
+              className="p-2 rounded-lg text-on-surface-variant hover:text-on-surface hover:bg-surface-variant/30 transition-colors"
+              title={isCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            >
+              <span className="material-symbols-outlined text-xl">
+                {isCollapsed ? "chevron_right" : "chevron_left"}
+              </span>
+            </button>
+          </div>
+          <nav className="px-2 pb-2 pt-4 space-y-1 flex-1">
+            {tabs.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
+                  activeTab === tab.id
+                    ? "bg-sidebar-active text-on-surface font-medium"
+                    : "text-on-surface hover:bg-surface-variant/20"
+                } ${isCollapsed ? "justify-center" : ""}`}
+                title={isCollapsed ? tab.label : undefined}
+              >
+                <Icon icon={tab.icon} size="sm" className="flex-shrink-0" />
+                {!isCollapsed && <span>{tab.label}</span>}
+              </button>
+            ))}
+          </nav>
+        </aside>
+
+        <main className="flex-1 overflow-y-auto">
+          <div className="p-6 lg:p-8">
+            <div className="lg:hidden mb-6">
+              <Select
+                value={activeTab}
+                onChange={(e) => setActiveTab(e.target.value as Tab)}
+              >
+                {tabs.map((tab) => (
+                  <option key={tab.id} value={tab.id}>
+                    {tab.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+
+            {activeTab === "profile" && <ProfileTab />}
+            {activeTab === "preferences" && <PreferencesTab />}
+            {activeTab === "encryption" && <EncryptionTab />}
+            {activeTab === "users" && <UsersTab />}
+            {activeTab === "audit-logs" && <AuditLogsTab />}
+          </div>
+        </main>
+      </div>
+    </FilesPageWrapper>
+  );
+}
+
+export default function SettingsPage() {
+  return (
     <FilesPageBorderWrapper>
       <SidebarProvider>
-        <FilesPageWrapper folderPath="">
-          <div className="flex-shrink-0">
-            <TopAppBar
-              leading={
-                <Link
-                  href="/"
-                  className="flex items-center justify-center leading-[0] gap-2 pt-8 pb-2 -ml-4"
-                >
-                  <Logo className="w-16 h-16 lg:w-20 lg:h-20" hideBox={true} />
-                </Link>
-              }
-              trailing={
-                <div className="flex items-center gap-2">
-                  <ThemeSelector />
-                  <UserMenu />
-                </div>
-              }
-            />
-          </div>
-          <div className="flex flex-1 overflow-hidden min-h-0">
-            <aside className="hidden lg:block w-96 bg-sidebar overflow-y-auto flex-shrink-0">
-              <nav className="px-2 pb-2 pt-6 space-y-1">
-                {tabs.map((tab) => (
-                  <button
-                    key={tab.id}
-                    onClick={() => setActiveTab(tab.id)}
-                    className={`w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
-                      activeTab === tab.id
-                        ? "bg-sidebar-active text-on-surface font-medium"
-                        : "text-on-surface hover:bg-surface-variant/20"
-                    }`}
-                  >
-                    <Icon icon={tab.icon} size="sm" />
-                    {tab.label}
-                  </button>
-                ))}
-              </nav>
-            </aside>
-
-            <main className="flex-1 overflow-y-auto">
-              <div className="p-6 lg:p-8">
-                <div className="lg:hidden mb-6">
-                  <Select
-                    value={activeTab}
-                    onChange={(e) => setActiveTab(e.target.value as Tab)}
-                  >
-                    {tabs.map((tab) => (
-                      <option key={tab.id} value={tab.id}>
-                        {tab.label}
-                      </option>
-                    ))}
-                  </Select>
-                </div>
-
-                {activeTab === "profile" && <ProfileTab />}
-                {activeTab === "preferences" && <PreferencesTab />}
-                {activeTab === "encryption" && <EncryptionTab />}
-                {activeTab === "users" && <UsersTab />}
-                {activeTab === "audit-logs" && <AuditLogsTab />}
-              </div>
-            </main>
-          </div>
-        </FilesPageWrapper>
+        <SettingsContent />
       </SidebarProvider>
     </FilesPageBorderWrapper>
   );

--- a/app/_components/GlobalComponents/Folders/FolderTreeNode.tsx
+++ b/app/_components/GlobalComponents/Folders/FolderTreeNode.tsx
@@ -19,6 +19,7 @@ interface FolderTreeNodeProps {
   folderTreeHook: ReturnType<typeof useFolderTree>;
   variant: "sidebar" | "dropdown";
   onFolderSelect?: (folderId: string | null) => void;
+  isCollapsed?: boolean;
 }
 
 export default function FolderTreeNode({
@@ -27,6 +28,7 @@ export default function FolderTreeNode({
   folderTreeHook,
   variant,
   onFolderSelect,
+  isCollapsed = false,
 }: FolderTreeNodeProps) {
   const {
     creatingInFolder,
@@ -159,6 +161,63 @@ export default function FolderTreeNode({
     .split("/")
     .map(encodeURIComponent)
     .join("/")}`;
+
+  // Collapsed mode: show only icons at root level
+  if (isCollapsed && level === 0) {
+    return (
+      <div className="select-none">
+        <Link
+          href={folderHref}
+          data-folder-id={folder.id}
+          className="block"
+          title={folder.name}
+        >
+          <div
+            className={`flex items-center justify-center p-2 rounded-lg mb-1 transition-colors cursor-pointer ${
+              folderIsActive
+                ? "bg-sidebar-active text-on-surface"
+                : "text-on-surface hover:bg-surface-variant/20"
+            }`}
+            onContextMenu={handleContextMenuEvent}
+          >
+            {(() => {
+              let folderUser = null;
+              const userSpecificMatch = folder.id.match(/^([^\/]+)\//);
+              if (userSpecificMatch) {
+                folderUser = allUsers.find(
+                  (u) => u.username === userSpecificMatch[1]
+                );
+              } else {
+                folderUser = allUsers.find((u) => u.username === folder.name);
+              }
+
+              if (folderUser) {
+                return (
+                  <UserAvatar
+                    user={folderUser}
+                    size="sm"
+                    className="flex-shrink-0"
+                  />
+                );
+              }
+
+              return (
+                <Icon
+                  icon={folder.id === "" ? "home" : "folder"}
+                  size="sm"
+                  className={`flex-shrink-0 ${
+                    folderIsActive
+                      ? "text-on-surface"
+                      : "text-on-surface-variant"
+                  }`}
+                />
+              );
+            })()}
+          </div>
+        </Link>
+      </div>
+    );
+  }
 
   return (
     <div className="select-none">
@@ -361,7 +420,7 @@ export default function FolderTreeNode({
         </div>
       )}
 
-      {folderIsExpanded && folder.children && folder.children.length > 0 && (
+      {folderIsExpanded && folder.children && folder.children.length > 0 && !isCollapsed && (
         <div className="mt-1">
           {folder.children.map((child) => (
             <FolderTreeNode
@@ -371,6 +430,7 @@ export default function FolderTreeNode({
               folderTreeHook={folderTreeHook}
               variant={variant}
               onFolderSelect={onFolderSelect}
+              isCollapsed={isCollapsed}
             />
           ))}
         </div>

--- a/app/_components/GlobalComponents/Folders/FolderTreeSidebar.tsx
+++ b/app/_components/GlobalComponents/Folders/FolderTreeSidebar.tsx
@@ -11,12 +11,14 @@ interface FolderTreeSidebarProps {
   folderTreeHook?: ReturnType<typeof useFolderTree>;
   showSearch?: boolean;
   showCreate?: boolean;
+  isCollapsed?: boolean;
 }
 
 export default function FolderTreeSidebar({
   folderTreeHook: providedHook,
   showSearch = false,
   showCreate = true,
+  isCollapsed = false,
 }: FolderTreeSidebarProps) {
   const [currentFolderId, setCurrentFolderId] = useState<string | null>(null);
   const pathname = usePathname();
@@ -50,7 +52,7 @@ export default function FolderTreeSidebar({
 
   return (
     <div className="h-full flex flex-col bg-sidebar">
-      {showSearch && (
+      {showSearch && !isCollapsed && (
         <div className="px-3 py-2 border-b border-outline-variant/20">
           <div className="relative">
             <Icon
@@ -69,7 +71,9 @@ export default function FolderTreeSidebar({
         </div>
       )}
 
-      <div className="flex-1 overflow-y-auto overflow-x-hidden px-2 pb-2 pt-6 min-w-0">
+      <div className={`flex-1 overflow-y-auto overflow-x-hidden pb-2 pt-4 min-w-0 ${
+        isCollapsed ? "px-1" : "px-2"
+      }`}>
         <div className="space-y-1">
           <FolderTreeNode
             key="root"
@@ -84,6 +88,7 @@ export default function FolderTreeSidebar({
             level={0}
             folderTreeHook={folderTreeHook}
             variant="sidebar"
+            isCollapsed={isCollapsed}
           />
 
           {filteredTree.map((folder: any) => (
@@ -93,6 +98,7 @@ export default function FolderTreeSidebar({
               level={0}
               folderTreeHook={folderTreeHook}
               variant="sidebar"
+              isCollapsed={isCollapsed}
             />
           ))}
         </div>

--- a/app/_components/GlobalComponents/Layout/TopAppBar.tsx
+++ b/app/_components/GlobalComponents/Layout/TopAppBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ReactNode } from "react";
+import { useSidebar } from "@/app/_providers/SidebarProvider";
 
 interface TopAppBarProps {
   title?: string;
@@ -13,9 +14,13 @@ export default function TopAppBar({
   leading,
   trailing,
 }: TopAppBarProps) {
+  const { isCollapsed } = useSidebar();
+  
   return (
     <header className="z-50 bg-surface relative">
-      <div className="absolute left-0 top-0 bottom-0 w-96 bg-sidebar hidden lg:block" />
+      <div className={`absolute left-0 top-0 bottom-0 bg-sidebar hidden lg:block transition-all duration-300 ease-in-out ${
+        isCollapsed ? "w-16" : "w-64"
+      }`} />
 
       <div className="h-16 px-4 flex items-center justify-between gap-4 relative z-10">
         <div className="flex items-center gap-4">

--- a/app/_providers/SidebarProvider.tsx
+++ b/app/_providers/SidebarProvider.tsx
@@ -1,26 +1,60 @@
 "use client";
 
-import { createContext, useContext, useState, ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+
+const SIDEBAR_COLLAPSED_KEY = "scatola-sidebar-collapsed";
 
 interface SidebarContextType {
   isSidebarOpen: boolean;
   toggleSidebar: () => void;
   openSidebar: () => void;
   closeSidebar: () => void;
+  isCollapsed: boolean;
+  toggleCollapse: () => void;
+  setCollapsed: (collapsed: boolean) => void;
 }
 
 const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 
 export const SidebarProvider = ({ children }: { children: ReactNode }) => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isInitialized, setIsInitialized] = useState(false);
+
+  // Load collapsed state from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
+    if (stored !== null) {
+      setIsCollapsed(stored === "true");
+    }
+    setIsInitialized(true);
+  }, []);
+
+  // Persist collapsed state to localStorage
+  useEffect(() => {
+    if (isInitialized) {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(isCollapsed));
+    }
+  }, [isCollapsed, isInitialized]);
 
   const toggleSidebar = () => setIsSidebarOpen((prev) => !prev);
   const openSidebar = () => setIsSidebarOpen(true);
   const closeSidebar = () => setIsSidebarOpen(false);
+  
+  const toggleCollapse = () => setIsCollapsed((prev) => !prev);
+  const setCollapsed = (collapsed: boolean) => setIsCollapsed(collapsed);
 
   return (
     <SidebarContext.Provider
-      value={{ isSidebarOpen, toggleSidebar, openSidebar, closeSidebar }}
+      value={{
+        isSidebarOpen,
+        toggleSidebar,
+        openSidebar,
+        closeSidebar,
+        isCollapsed,
+        toggleCollapse,
+        setCollapsed,
+      }}
     >
       {children}
     </SidebarContext.Provider>


### PR DESCRIPTION
## Collapsible Sidebar

Adds a toggle button to collapse/expand the folder sidebar.

### Features
- Click the chevron (◀/▶) at the top of the sidebar to toggle
- **Collapsed:** 64px width, shows only folder icons
- **Expanded:** 256px width (reduced from previous 384px)
- State persists in localStorage across browser sessions
- Works on both Files page and Settings page
- Desktop only (mobile continues to use existing slide-out drawer)

### Files Changed
- `SidebarProvider.tsx` - Added `isCollapsed` state with localStorage persistence
- `MobileSidebarWrapper.tsx` - Dynamic width + collapse toggle button
- `TopAppBar.tsx` - Sidebar background matches dynamic width
- `SettingsPage.tsx` - Collapsible settings sidebar
- `FolderTreeSidebar.tsx` - Pass `isCollapsed` prop to child nodes
- `FolderTreeNode.tsx` - Icon-only mode when collapsed

### Testing
- Tested collapse/expand toggle
- Verified state persistence after page refresh
- Tested on Files page and Settings page